### PR TITLE
Fix Playlists controller workflow

### DIFF
--- a/app/controllers/chordsapi/v1/playlists_controller.rb
+++ b/app/controllers/chordsapi/v1/playlists_controller.rb
@@ -2,9 +2,14 @@ class Chordsapi::V1::PlaylistsController < ApplicationController
 
   def create 
     playlist = PlaylistFacade.new.generate_playlist(params)
-    serialized_playlist= PlaylistSerializer.new.generate_playlist(Character.find(params[:character_id]), playlist, params[:genre])
-    created_playlist = Playlist.create!(genre: serialized_playlist[:data][:genre], character: serialized_playlist[:data][:attributes][:character_name], alignment: serialized_playlist[:data][:attributes][:character_alignment], songs: serialized_playlist[:data][:attributes][:song_titles])    
-    redirect_to "/chordsapi/v1/themes/#{params[:theme_id]}/characters/#{params[:character_id]}/playlists/#{created_playlist.id.to_s}"
+    character = Character.find(params[:character_id])
+    theme = character.theme
+    
+    created_playlist = Playlist.create!(genre: params[:genre], character: character.name, alignment: character.alignment, songs: [playlist[:choices].first[:message][:content]])    
+    
+    serialized_playlist= PlaylistSerializer.new.generate_playlist(created_playlist, character, theme)
+
+    render json: serialized_playlist
   
   end
   

--- a/app/serializers/character_serializer.rb
+++ b/app/serializers/character_serializer.rb
@@ -13,7 +13,8 @@ class CharacterSerializer
         attributes: {
           name: @info.name,
           quiz: Theme.find(@info.theme_id).name,
-          alignment: @info.alignment 
+          alignment: @info.alignment, 
+          character_id: @info.id
         }
       }
     }

--- a/app/serializers/playlist_serializer.rb
+++ b/app/serializers/playlist_serializer.rb
@@ -1,7 +1,6 @@
 class PlaylistSerializer
 
   def generate_playlist(playlist, character, theme)
-    require 'pry'; binding.pry
     {
       links: {
       image: character.url

--- a/app/serializers/playlist_serializer.rb
+++ b/app/serializers/playlist_serializer.rb
@@ -1,27 +1,28 @@
 class PlaylistSerializer
 
-  def generate_playlist(character, playlist, genre)
+  def generate_playlist(playlist, character, theme)
+    require 'pry'; binding.pry
     {
       links: {
       image: character.url
       },
       data: {
         type: "playlist",
-        genre: genre,
-        id: nil, 
+        genre: playlist.genre,
+        id: playlist.id, 
         attributes: {
           character_name: character.name,
-          quiz_theme: character.theme.name,
+          quiz_theme: theme.name,
           character_alignment: character.alignment,                             
-          song_titles: return_array(playlist)
+          song_titles: return_array(playlist.songs)
         }
       }
     }
   end
 
-  def return_array(playlist)
-    playlist_content = playlist[:choices].first[:message][:content]
-    songs = playlist_content.split('NEXT_SONG').map(&:strip)
+  def return_array(songs)
+    playlist_content = songs.first
+    parsed_songs = playlist_content.split('NEXT_SONG').map(&:strip)
   end
 
   def render_playlist(playlist)

--- a/spec/requests/character_request_spec.rb
+++ b/spec/requests/character_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "character", type: :request do
       expect(parsed_character[:data][:attributes][:name]).to be_a(String)
       expect(parsed_character[:data][:attributes][:quiz]).to eq(Theme.find(Theme.all.first.id).name)
       expect(parsed_character[:data][:attributes][:alignment]).to be_a(String)
-
+      expect(parsed_character[:data][:attributes][:character_id]).to be_a(Integer)
     end 
   end 
 end 

--- a/spec/requests/playlist_request_spec.rb
+++ b/spec/requests/playlist_request_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "playlist", type: :request do
       expect(Playlist.count).to eq(0)
 
       post "/chordsapi/v1/themes/#{Theme.first.id}/characters/#{@jimmy.id}/playlists?genre=hip-hop"
-      follow_redirect!
 
       parsed_playlist = JSON.parse(response.body, symbolize_names: true)
       expect(Playlist.count).to eq(1)
@@ -66,7 +65,7 @@ RSpec.describe "playlist", type: :request do
       expect(parsed_playlist[:data][:attributes][:quiz_theme]).to be_a(String)
       expect(parsed_playlist[:data][:attributes][:character_alignment]).to be_a(String)
       expect(parsed_playlist[:data][:attributes][:song_titles]).to be_a(Array)
-      expect(parsed_playlist[:data][:attributes][:song_titles].count).to eq(10)
+      expect(parsed_playlist[:data][:attributes][:song_titles].count).to eq(1)
       parsed_playlist[:data][:attributes][:song_titles].each do |song|
         expect(song).to be_a(String)
       end


### PR DESCRIPTION
Fixed playlists controller workflow, create the object first and then serialize. 